### PR TITLE
Fix uncaught AttributeError

### DIFF
--- a/cpp_pretty_frame.py
+++ b/cpp_pretty_frame.py
@@ -106,4 +106,4 @@ class PrettyFrame:
                     print(e)
                 nested = []
 
-        return self.format_nested(nested.asList())
+        return self.format_nested([] if nested == [] else nested.asList())


### PR DESCRIPTION
Fixes this error:
Expected {W:(_ABC...) | "{" | "}" | "(" | ")" | "*" | "&" | "," | W:(::) | nested <> expression} (at char 4), (line:1, col:5)
Traceback (most recent call last):
  File "/usr/share/glib-2.0/gdb/gobject_gdb.py", line 286, in next
    emission = self.find_signal_emission ()
  File "/usr/share/glib-2.0/gdb/gobject_gdb.py", line 274, in find_signal_emission
    if frame_name(self.queue[i]) == "signal_emit_unlocked_R":
  File "/usr/share/glib-2.0/gdb/gobject_gdb.py", line 148, in frame_name
    return str(frame.function())
  File "/.../gdb-pretty-frame-cpp/framefilter.py", line 16, in function
    name = self.frame_printer.parse_line(str(frame.name()))
  File "/.../gdb-pretty-frame-cpp/cpp_pretty_frame.py", line 109, in parse_line
    return self.format_nested(nested.asList())
AttributeError: 'list' object has no attribute 'asList'