### PR TITLE
Support lambda expressions in stack trace

### DIFF
--- a/cpp_pretty_frame.py
+++ b/cpp_pretty_frame.py
@@ -27,7 +27,7 @@ class PrettyFrame:
     def __init__(self):
         self.enclosed = pyp.Forward()
         nestedAngles = pyp.nestedExpr('<', '>', content=self.enclosed)
-        self.enclosed << (pyp.Word('_' + pyp.alphanums) | '{' | '}' |
+        self.enclosed << (pyp.Word('_' + pyp.alphanums) | '{' | '}' | '#' |
                           '(' | ')' | '*' | '&' | ',' | pyp.Word("::") |
                           nestedAngles)
 


### PR DESCRIPTION
Correctly parse snippets like
`::{lambda(auto:1&)#1}`